### PR TITLE
#221: Fix stack overflow when loading plans with more than 700 steps

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -73,7 +73,7 @@ lazy val ui =
       libraryDependencies ++= List(
         "org.scala-js" %%% "scalajs-dom" % "2.8.0",
         ("org.scala-js" %%% "scalajs-java-securerandom" % "1.0.0").cross(CrossVersion.for3Use2_13),
-        "com.raquo" %%% "laminar" % "16.0.0",
+        "com.raquo" %%% "laminar" % "17.1.0",
         "io.circe" %%% "circe-scalajs" % circeVersion
       ),
       scalaJSUseMainModuleInitializer := true,

--- a/ui/src/main/scala/ddm/ui/dom/common/form/ValidatedFileInput.scala
+++ b/ui/src/main/scala/ddm/ui/dom/common/form/ValidatedFileInput.scala
@@ -18,7 +18,7 @@ object ValidatedFileInput {
     fileSignal: Signal[Option[File]],
     parse: File => EventStream[Either[Throwable, T]]
   ): Signal[Option[Either[Throwable, T]]] =
-    fileSignal.flatMap {
+    fileSignal.flatMapSwitch {
       case Some(file) => parse(file).map(Some.apply).toSignal(initial = None)
       case None => Signal.fromValue(None)
     }

--- a/ui/src/main/scala/ddm/ui/dom/editor/NewRequirementForm.scala
+++ b/ui/src/main/scala/ddm/ui/dom/editor/NewRequirementForm.scala
@@ -134,9 +134,11 @@ object NewRequirementForm {
     levelSignal: Signal[Option[SkillLevel]]
   ): EventStream[Option[Requirement]] =
     formSubmissions.sample(
-      effectTypeSignal.flatMap {
-        case RequirementType.Tool => toolSignal
-        case RequirementType.SkillLevel => levelSignal.map(identity)
-      }
+      Signal
+        .combine(effectTypeSignal, toolSignal, levelSignal)
+        .map {
+          case (RequirementType.Tool, tool, _) => tool
+          case (RequirementType.SkillLevel, _, skillLevel) => skillLevel.map(identity)
+        }
     )
 }

--- a/ui/src/main/scala/ddm/ui/dom/landing/form/NewPlanForm.scala
+++ b/ui/src/main/scala/ddm/ui/dom/landing/form/NewPlanForm.scala
@@ -24,7 +24,7 @@ import scala.scalajs.js.annotation.JSImport
 object NewPlanForm {
   def apply(
     storage: StorageClient,
-    planObserver: Observer[(Plan, PlanSubscription)], 
+    planObserver: Observer[(Plan, PlanSubscription)],
     toastPublisher: ToastHub.Publisher
   ): L.FormElement = {
     val (nameInput, nameLabel, nameSignal) = createNameInput()

--- a/ui/src/main/scala/ddm/ui/dom/landing/menu/DownloadButton.scala
+++ b/ui/src/main/scala/ddm/ui/dom/landing/menu/DownloadButton.scala
@@ -32,7 +32,7 @@ object DownloadButton {
     storage: StorageClient,
     toastPublisher: ToastHub.Publisher
   ): EventStream[Unit] =
-    storage.fetch(id).changes.collectSome.flatMap {
+    storage.fetch(id).changes.collectSome.flatMapSwitch {
       case Left(error) =>
         toastPublisher.publish(
           ToastHub.Type.Warning,

--- a/ui/src/main/scala/ddm/ui/dom/plan/StepElement.scala
+++ b/ui/src/main/scala/ddm/ui/dom/plan/StepElement.scala
@@ -147,7 +147,7 @@ object StepElement {
     L.button(
       L.`type`("button"),
       "Cut",
-      L.onClick.ifUnhandledF(_.flatMap { event =>
+      L.onClick.ifUnhandledF(_.flatMapSwitch { event =>
         event.preventDefault()
         window.navigator.clipboard.writeText(stepID).asObservable
       }) --> closer
@@ -166,7 +166,7 @@ object StepElement {
     L.button(
       L.`type`("button"),
       "Paste",
-      L.onClick.ifUnhandledF(_.flatMap { event =>
+      L.onClick.ifUnhandledF(_.flatMapSwitch { event =>
         event.preventDefault()
         window.navigator.clipboard.readText().asObservable
       }) --> Observer.combine(stepMover, closer)

--- a/ui/src/main/scala/ddm/ui/storage/model/PlanMetadata.scala
+++ b/ui/src/main/scala/ddm/ui/storage/model/PlanMetadata.scala
@@ -18,8 +18,8 @@ object PlanMetadata {
   
   def apply(name: String): PlanMetadata =
     PlanMetadata(
-      name, 
-      new Date(Date.now()), 
+      name,
+      new Date(Date.now()),
       SchemaVersion.values.last
     )
 }

--- a/ui/src/main/scala/ddm/ui/storage/opfs/RootDirectory.scala
+++ b/ui/src/main/scala/ddm/ui/storage/opfs/RootDirectory.scala
@@ -7,12 +7,9 @@ import ddm.ui.wrappers.workers.WorkerScope
 
 object RootDirectory {
   def from(scope: WorkerScope): EventStream[Either[FileSystemError, RootDirectory]] =
-    for {
-      root <- scope.navigator.storage.getDirectory().asObservable
-      maybePlans <- DirectoryHandle(root).acquireSubDirectory("plans")
-    } yield maybePlans.map(plans =>
-      RootDirectory(PlansDirectory(plans))
-    )
+    scope.navigator.storage.getDirectory().asObservable
+      .flatMapSwitch(root => DirectoryHandle(root).acquireSubDirectory("plans"))
+      .map(_.map(plans => RootDirectory(PlansDirectory(plans))))
 }
 
 final class RootDirectory(val plans: PlansDirectory)

--- a/ui/src/main/scala/ddm/ui/storage/opfs/StepsDirectory.scala
+++ b/ui/src/main/scala/ddm/ui/storage/opfs/StepsDirectory.scala
@@ -7,6 +7,8 @@ import ddm.ui.storage.opfs.StepsDirectory.*
 import ddm.ui.utils.airstream.EventStreamOps.andThen
 import ddm.ui.wrappers.opfs.{DirectoryHandle, FileSystemError}
 
+import scala.util.chaining.scalaUtilChainingOps
+
 object StepsDirectory {
   private def toFileName(id: Step.ID): String =
     s"$id.bin"
@@ -19,13 +21,14 @@ final class StepsDirectory(underlying: DirectoryHandle) {
   def write(step: Step): EventStream[Either[FileSystemError, ?]] =
     underlying.replaceFileContent(toFileName(step.id), step.details)
   
-  def write(steps: Iterable[Step]): EventStream[Either[FileSystemError, ?]] = {
-    val zero = EventStream.fromValue[Either[FileSystemError, ?]](Right(()), emitOnce = true)
-
-    steps.foldLeft(zero)((acc, step) =>
-      acc.andThen(_ => write(step))
-    )
-  }
+  def write(steps: Iterable[Step]): EventStream[Either[FileSystemError, ?]] =
+    EventStream
+      .sequence(steps.map(write).toSeq)
+      .map(results =>
+        results
+          .collectFirst { case l @ Left(_) => l }
+          .getOrElse(Right(()))
+      )
   
   def remove(id: Step.ID): EventStream[Either[FileSystemError.UnexpectedFileSystemError, ?]] =
     underlying.removeFile(toFileName(id))
@@ -36,26 +39,25 @@ final class StepsDirectory(underlying: DirectoryHandle) {
       .map(_.map(Step(id, _)))
   
   def read(ids: Iterable[Step.ID]): EventStream[Either[FileSystemError, Map[Step.ID, Step]]] = {
-    val zero = EventStream.fromValue[Either[FileSystemError, Map[Step.ID, Step]]](Right(Map.empty), emitOnce = true)
-    
-    ids.foldLeft(zero)((streamAcc, id) =>
-      streamAcc.andThen(acc =>
-        read(id).map(_.map(step => acc + (id -> step)))
-      )
-    )
+    val zero: Either[FileSystemError, Map[Step.ID, Step]] = Right(Map.empty)
+
+    ids
+      .map(id => read(id).map(id -> _)).toSeq
+      .pipe(EventStream.sequence)
+      .map(_.foldLeft(zero) { case (maybeAcc, (stepID, maybeStep)) =>
+        for {
+          acc <- maybeAcc
+          step <- maybeStep
+        } yield acc + (stepID -> step)
+      })
   }
 
   def fetch(): EventStream[Either[FileSystemError, Map[Step.ID, Encoding]]] =
-    underlying.listFiles().andThen { fileNames =>
-      val zero = EventStream.fromValue(Map.empty[Step.ID, Encoding], emitOnce = true)
-      
-      fileNames.foldLeft(zero)((streamAcc, fileName) =>
-        streamAcc.flatMap(acc =>
-          underlying.read[Encoding](fileName).map {
-            case Left(_) => acc
-            case Right(encoding) => acc + (toStepID(fileName) -> encoding)  
-          }
-        )
-      ).map(Right(_))
-    }
+    underlying.listFiles().andThen(fileNames =>
+      fileNames
+        .map(fileName => underlying.read[Encoding](fileName).map(fileName -> _))
+        .pipe(EventStream.sequence)
+        .map(_.collect { case (fileName, Right(encoding)) => toStepID(fileName) -> encoding }.toMap)
+        .map(Right(_))
+    )
 }

--- a/ui/src/main/scala/ddm/ui/utils/airstream/EventStreamOps.scala
+++ b/ui/src/main/scala/ddm/ui/utils/airstream/EventStreamOps.scala
@@ -7,7 +7,7 @@ object EventStreamOps {
     def andThen[E2 >: E1, S](
       f: T => EventStream[Either[E2, S]]
     ): EventStream[Either[E2, S]] =
-      self.flatMap {
+      self.flatMapSwitch {
         case Left(error) => EventStream.fromValue(Left(error), emitOnce = true)
         case Right(value) => f(value)
       }

--- a/ui/src/main/scala/ddm/ui/utils/airstream/ObservableOps.scala
+++ b/ui/src/main/scala/ddm/ui/utils/airstream/ObservableOps.scala
@@ -15,7 +15,7 @@ object ObservableOps {
   extension [F[X] <: Observable[X], T](self: F[T]) {
     def flatMapConcat[S](f: T => EventStream[S]): BufferedStream[T, S] =
       new BufferedStream[T, S](self, f)
-      
+
     def withKillSwitch(resetOnStop: Boolean): KillSwitchedStream[T] =
       new KillSwitchedStream[T](self, resetOnStop)
   }

--- a/ui/src/main/scala/ddm/ui/wrappers/opfs/DirectoryHandle.scala
+++ b/ui/src/main/scala/ddm/ui/wrappers/opfs/DirectoryHandle.scala
@@ -58,7 +58,7 @@ final class DirectoryHandle(underlying: FileSystemDirectoryHandle) {
       .next()
       .asObservable
       .recoverToTry
-      .flatMap {
+      .flatMapSwitch {
         case Success(entry) if entry.done => liftValue(Right(acc))
         case Success(entry) => listContents(iterator, acc :+ entry.value)
         case Failure(ex) => liftValue(Left(UnexpectedFileSystemError(ex)))


### PR DESCRIPTION
- Laminar v17 improved the stack safety associated with chained observables
- Using EventStream.sequence further reduced the length of observable chains